### PR TITLE
Fixing messages dropped on buffer error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <div align="center"> Open MSI Python Code </div>
-#### <div align="center">***v0.8.3***</div>
+#### <div align="center">***v0.8.4***</div>
 
 #### <div align="center">Maggie Eminizer<sup>2</sup>, Sam Tabrisky<sup>3</sup>, Alakarthika Ulaganathan<sup>4</sup>, David Elbert<sup>1</sup></div>
 

--- a/openmsipython/data_file_io/data_file_upload_directory.py
+++ b/openmsipython/data_file_io/data_file_upload_directory.py
@@ -26,6 +26,7 @@ class DataFileUploadDirectory(DataFileDirectory,ControlledProcessSingleThread,Ru
     @property
     def progress_msg(self) :
         self.__find_new_files()
+        progress_msg = f'Producer has successfully served {self.__producer.n_callbacks_served} message callbacks. '
         progress_msg = 'The following files have been recognized so far:\n'
         for datafile in self.data_files_by_path.values() :
             if not datafile.to_upload :

--- a/openmsipython/data_file_io/data_file_upload_directory.py
+++ b/openmsipython/data_file_io/data_file_upload_directory.py
@@ -26,7 +26,7 @@ class DataFileUploadDirectory(DataFileDirectory,ControlledProcessSingleThread,Ru
     @property
     def progress_msg(self) :
         self.__find_new_files()
-        progress_msg = f'Producer has successfully served {self.__producer.n_callbacks_served} message callbacks. '
+        progress_msg = f'Producer has served {self.__producer.n_callbacks_served} message callbacks. '
         progress_msg += 'The following files have been recognized so far:\n'
         for datafile in self.data_files_by_path.values() :
             if not datafile.to_upload :

--- a/openmsipython/data_file_io/data_file_upload_directory.py
+++ b/openmsipython/data_file_io/data_file_upload_directory.py
@@ -27,7 +27,7 @@ class DataFileUploadDirectory(DataFileDirectory,ControlledProcessSingleThread,Ru
     def progress_msg(self) :
         self.__find_new_files()
         progress_msg = f'Producer has successfully served {self.__producer.n_callbacks_served} message callbacks. '
-        progress_msg = 'The following files have been recognized so far:\n'
+        progress_msg += 'The following files have been recognized so far:\n'
         for datafile in self.data_files_by_path.values() :
             if not datafile.to_upload :
                 continue

--- a/openmsipython/data_file_io/data_file_upload_directory.py
+++ b/openmsipython/data_file_io/data_file_upload_directory.py
@@ -127,7 +127,7 @@ class DataFileUploadDirectory(DataFileDirectory,ControlledProcessSingleThread,Ru
             self.__find_new_files()
             if not self.have_file_to_upload :
                 if self.__wait_time<self.MAX_WAIT_TIME :
-                    self.__wait_time*=1.5
+                    self.__wait_time*=1.1
             else :
                 self.__wait_time = self.MIN_WAIT_TIME
         #find the first file that's running and add some of its chunks to the upload queue 
@@ -141,6 +141,8 @@ class DataFileUploadDirectory(DataFileDirectory,ControlledProcessSingleThread,Ru
     def _on_check(self) :
         #log progress so far
         self.logger.debug(self.progress_msg)
+        #reset the wait time
+        self.__wait_time = self.MIN_WAIT_TIME
 
     def _on_shutdown(self) :
         self.logger.info('Will quit after all currently enqueued files are done being transferred.')

--- a/openmsipython/data_file_io/upload_data_file.py
+++ b/openmsipython/data_file_io/upload_data_file.py
@@ -55,7 +55,10 @@ class UploadDataFile(DataFile,Runnable) :
         if not self.__to_upload :
             msg+='(will not be uploaded)'
         elif self.__fully_enqueued :
-            msg+=f'({self.__n_total_chunks} messages fully enqueued)'
+            msg+=f'({self.__n_total_chunks} message'
+            if self.__n_total_chunks!=1 :
+                msg+='s'
+            msg+=' fully enqueued)'
         elif self.upload_in_progress :
             msg+=f'(in progress with {self.__n_total_chunks-len(self.__chunks_to_upload)}'
             msg+=f'/{self.__n_total_chunks} messages enqueued)'

--- a/openmsipython/my_kafka/my_producer.py
+++ b/openmsipython/my_kafka/my_producer.py
@@ -91,7 +91,7 @@ class MyProducer(LogOwner) :
                     self.logger.info(logmsg)
                 #produce the message to the topic
                 success=False; total_wait_secs=0 
-                if (not success) and total_wait_secs<timeout :
+                while (not success) and total_wait_secs<timeout :
                     try :
                         self.produce(topic=topic_name,key=obj.msg_key,value=obj.msg_value,on_delivery=producer_callback)
                         success=True

--- a/openmsipython/my_kafka/my_producer.py
+++ b/openmsipython/my_kafka/my_producer.py
@@ -104,7 +104,7 @@ class MyProducer(LogOwner) :
                     except BufferError :
                         n_new_callbacks = self.poll(0)
                         time.sleep(retry_sleep)
-                        if n_new_callbacks==0 :
+                        if n_new_callbacks is None or n_new_callbacks==0 :
                             total_wait_secs+=retry_sleep
                         else :
                             total_wait_secs = 0
@@ -117,7 +117,8 @@ class MyProducer(LogOwner) :
                 self.__poll_counter+=1
                 if self.__poll_counter%self.POLL_EVERY==0 :
                     n_new_callbacks = self.poll(0)
-                    self.__n_callbacks_served+=n_new_callbacks
+                    if n_new_callbacks is not None :
+                        self.__n_callbacks_served+=n_new_callbacks
                     self.__poll_counter = 0
             else :
                 warnmsg = f'WARNING: found an object of type {type(obj)} in a Producer queue that should only contain '

--- a/openmsipython/shared/controlled_process.py
+++ b/openmsipython/shared/controlled_process.py
@@ -67,6 +67,8 @@ class ControlledProcess(LogOwner,ABC) :
                 self.shutdown()
             elif cmd.lower() in ('c','check') : # run the on_check function
                 self._on_check()
+            else : # otherwise just skip this unrecognized command
+                self._check_control_command_queue()
 
     #################### ABSTRACT METHODS ####################
 

--- a/openmsipython/utilities/misc.py
+++ b/openmsipython/utilities/misc.py
@@ -7,7 +7,7 @@ def add_user_input(input_queue) :
     """
     while True :
         time.sleep(1)
-        input_queue.put(sys.stdin.read(1))
+        input_queue.put((sys.stdin.read(1)).strip())
 
 def populated_kwargs(given_kwargs,defaults,logger=None) :
     """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ site.ENABLE_USER_SITE = True #https://www.scivision.dev/python-pip-devel-user-in
 
 setupkwargs = dict(
     name='openmsipython',
-    version='0.8.3',
+    version='0.8.4',
     packages=setuptools.find_packages(include=['openmsipython*']),
     include_package_data=True,
     entry_points = {

--- a/test/unittests/test_upload_data_file.py
+++ b/test/unittests/test_upload_data_file.py
@@ -30,7 +30,6 @@ class TestUploadDataFile(unittest.TestCase) :
         self.assertFalse(self.datafile.fully_enqueued)
         self.assertTrue(self.datafile.waiting_to_upload)
         self.assertFalse(self.datafile.upload_in_progress)
-        self.assertEqual(self.datafile.upload_status_msg,f'{TEST_CONST.TEST_DATA_FILE_PATH.relative_to(self.datafile.rootdir)} (waiting to be enqueued)')
 
     def test_add_chunks_to_upload_queue(self) :
         #adding to a full Queue should do nothing
@@ -49,7 +48,6 @@ class TestUploadDataFile(unittest.TestCase) :
         n_total_chunks = len(self.datafile.chunks_to_upload)
         self.assertFalse(self.datafile.waiting_to_upload)
         self.assertTrue(self.datafile.upload_in_progress)
-        self.assertEqual(self.datafile.upload_status_msg,f'{TEST_CONST.TEST_DATA_FILE_PATH.relative_to(self.datafile.rootdir)} (in progress)')
         self.assertFalse(self.datafile.fully_enqueued)
         self.datafile.add_chunks_to_upload_queue(real_queue,n_threads=RUN_OPT_CONST.N_DEFAULT_UPLOAD_THREADS)
         self.datafile.add_chunks_to_upload_queue(real_queue,n_threads=RUN_OPT_CONST.N_DEFAULT_UPLOAD_THREADS)
@@ -58,7 +56,6 @@ class TestUploadDataFile(unittest.TestCase) :
         self.assertEqual(real_queue.qsize(),n_total_chunks)
         self.assertFalse(self.datafile.waiting_to_upload)
         self.assertFalse(self.datafile.upload_in_progress)
-        self.assertEqual(self.datafile.upload_status_msg,f'{TEST_CONST.TEST_DATA_FILE_PATH.relative_to(self.datafile.rootdir)} (fully enqueued)')
         self.assertTrue(self.datafile.fully_enqueued)
         #and try one more time to add more chunks; this should just return without doing anything
         self.datafile.add_chunks_to_upload_queue(real_queue)


### PR DESCRIPTION
This PR fixes an issue where messages would be dropped if they couldn't be buffered in time. They now wait patiently if the producer is continuing to serve callbacks, and if they still fail then they get re-enqueued instead of just fully dropped.