### PR TITLE
update for new version of KafkaCrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <div align="center"> Open MSI Python Code </div>
-#### <div align="center">***v0.9.0***</div>
+#### <div align="center">***v0.9.1***</div>
 
 #### <div align="center">Maggie Eminizer<sup>2</sup>, Sam Tabrisky<sup>3</sup>, Alakarthika Ulaganathan<sup>4</sup>, David Elbert<sup>1</sup></div>
 

--- a/openmsipython/my_kafka/my_consumer.py
+++ b/openmsipython/my_kafka/my_consumer.py
@@ -124,7 +124,10 @@ class MyConsumer(LogOwner) :
         if (message is not None) and (not isinstance(message,Message)) :
             try :
                 offset_dict = {KCCommitOffsetDictKey(message.topic,message.partition):KCCommitOffset(message.offset)}
-                return self.__consumer.commit(offsets=offset_dict)#,asynchronous=asynchronous) #will add this back in
+                if asynchronous :
+                    return self.__consumer.commit_async(offsets=offset_dict)
+                else :
+                    return self.__consumer.commit(offsets=offset_dict)
             except :
                 warnmsg = 'WARNING: failed to commit an offset for an encrypted message. '
                 warnmsg = 'Duplicates may result if the Consumer is restarted.'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ site.ENABLE_USER_SITE = True #https://www.scivision.dev/python-pip-devel-user-in
 
 setupkwargs = dict(
     name='openmsipython',
-    version='0.9.0',
+    version='0.9.1',
     packages=setuptools.find_packages(include=['openmsipython*']),
     include_package_data=True,
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setupkwargs = dict(
     install_requires=['atomicwrites>=1.4.0',
                       'confluent-kafka>=1.8.2',
                       'gemd>=1.8.1',
-                      'kafkacrypto>=0.9.9.12',
+                      'kafkacrypto>=0.9.9.14.post1',
                       'matplotlib',
                       'methodtools',
                       'msgpack',


### PR DESCRIPTION
This PR adds support for the latest version of KafkaCrypto, which includes an asynchronous Consumer commit option as well as a preventative measure for an issue in the latest version of librdkafka