### PR TITLE
Bugfix for registering files with only one chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <div align="center"> Open MSI Python Code </div>
-#### <div align="center">***v0.9.2.0***</div>
+#### <div align="center">***v0.9.2.1***</div>
 
 #### <div align="center">Maggie Eminizer<sup>2</sup>, Amir Sharifzadeh<sup>2</sup>, Sam Tabrisky<sup>3</sup>, Alakarthika Ulaganathan<sup>4</sup>, David Elbert<sup>1</sup></div>
 

--- a/openmsipython/data_file_io/producer_file_registry.py
+++ b/openmsipython/data_file_io/producer_file_registry.py
@@ -118,15 +118,24 @@ class ProducerFileRegistry(LogOwner) :
                 return True
             else :
                 return False
-        #otherwise it's a new file to add to "in_progress"
+        #otherwise it's a new file to list somewhere
         else :
             to_deliver = set([])
             for ic in range(1,n_total_chunks+1) :
                 if ic!=chunk_i :
                     to_deliver.add(ic)
-            in_prog_entry = RegistryLineInProgress(filename,filepath,n_total_chunks,
-                                                   1,n_total_chunks-1,datetime.datetime.now(),
-                                                   set([chunk_i]),to_deliver)
-            self.__in_prog.add_entries(in_prog_entry)
-            self.__in_prog.dump_to_file()
-            return False
+            #if there are other chunks to deliver, register it to "in_progress"
+            if len(to_deliver)>0 :
+                in_prog_entry = RegistryLineInProgress(filename,filepath,n_total_chunks,
+                                                       1,n_total_chunks-1,datetime.datetime.now(),
+                                                       set([chunk_i]),to_deliver)
+                self.__in_prog.add_entries(in_prog_entry)
+                self.__in_prog.dump_to_file()
+                return False
+            #otherwise register it as a completed file
+            else :
+                completed_entry = RegistryLineCompleted(filename,filepath,n_total_chunks,
+                                                        datetime.datetime.now(),datetime.datetime.now())
+                self.__completed.add_entries(completed_entry)
+                self.__completed.dump_to_file()
+                return True

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ site.ENABLE_USER_SITE = True #https://www.scivision.dev/python-pip-devel-user-in
 
 setupkwargs = dict(
     name='openmsipython',
-    version='0.9.2.0',
+    version='0.9.2.1',
     packages=setuptools.find_packages(include=['openmsipython*']),
     include_package_data=True,
     entry_points = {


### PR DESCRIPTION
This PR fixes a bug that would fail to register files with only one chunk as "fully-produced" in the .csv file