### PR TITLE
Updating tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   # Build the repo and check the code using pyflakes 
   build-and-code-check:
     docker:
-      - image: containers.repo.sciserver.org/openmsipython:1.0.0
+      - image: containers.repo.sciserver.org/openmsipython:1.1.0
         auth:
           username: $IDIESDOCKER_USERNAME
           password: $IDIESDOCKER_PASSWORD
@@ -42,11 +42,12 @@ jobs:
   # Run unittests 
   run-tests:
     docker:
-      - image: containers.repo.sciserver.org/openmsipython:1.0.0
+      - image: containers.repo.sciserver.org/openmsipython:1.1.0
         auth:
           username: $IDIESDOCKER_USERNAME
           password: $IDIESDOCKER_PASSWORD
     parallelism: 12
+    resource_class: large
     steps:
       - attach_workspace:
           at: .
@@ -66,7 +67,7 @@ jobs:
   # Make sure that the repository is clean after all tests have been run
   check-repo:
     docker:
-      - image: containers.repo.sciserver.org/openmsipython:1.0.0
+      - image: containers.repo.sciserver.org/openmsipython:1.1.0
         auth:
           username: $IDIESDOCKER_USERNAME
           password: $IDIESDOCKER_PASSWORD

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -4,14 +4,20 @@ FROM cimg/python:3.9
 # Switch to root user
 USER root
 
-# Install miniconda3
-ENV PATH="/root/miniconda3/bin:$PATH"
-ARG PATH="/root/miniconda3/bin:$PATH"
-RUN wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh 
+#start in the default area
+WORKDIR /
 
-# Install libsodium
-RUN conda install -c anaconda libsodium
+#install libsodium
+RUN apt-get update -y && \
+    apt-get install -y libsodium-dev
+
+#install git
+RUN apt-get install -y git
+
+#clone the openmsipython repo and install it
+RUN git clone https://github.com/openmsi/openmsipython.git
+WORKDIR /openmsipython
+RUN pip install .
+
+#switch back to the default area
+WORKDIR /

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <div align="center"> Open MSI Python Code </div>
-#### <div align="center">***v0.9.2.2***</div>
+#### <div align="center">***v0.9.2.3***</div>
 
 #### <div align="center">Maggie Eminizer<sup>2</sup>, Amir Sharifzadeh<sup>2</sup>, Sam Tabrisky<sup>3</sup>, Alakarthika Ulaganathan<sup>4</sup>, David Elbert<sup>1</sup></div>
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ site.ENABLE_USER_SITE = True #https://www.scivision.dev/python-pip-devel-user-in
 
 setupkwargs = dict(
     name='openmsipython',
-    version='0.9.2.2',
+    version='0.9.2.3',
     packages=setuptools.find_packages(include=['openmsipython*']),
     include_package_data=True,
     entry_points = {


### PR DESCRIPTION
This PR changes the version of the Docker image used by CircleCI to already have a bunch of dependencies installed so that tests load faster. In the future when dependencies update I can just rebuild the image, push it again, and update the tag to gain the same behavior, but nothing will change even if dependencies do in the meantime (they'll just take longer to load)