### PR TITLE
Refactoring of installation ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Developed for Open MSI (NSF DMREF award #1921959)
 Programs use the Python implementation of the Apache Kafka API, and are designed to run on Windows, Mac or Linux machines.  Data producers typically run on Windows or Linux computers that run collection of data on laboratory instruments; Data consumers and stream processors run on the same computers, on servers with more compute power as needed, or where storage of data is hosted.  In all these cases, Open MSI components are run in Python 3 in virtual environments or sometimes in Docker containers. Open MSI can be used interactively from the command line or run as an always available service (on Windows) or daemon (on Linux).  We recommend using a minimal installation of the conda open source package management system and environment management system. These installation instructions start with installation of conda and outline all the necessary steps to run Open MSI tools.  To run Open MSI usefully, you need to understand that data streams through *topics* served by a *broker*.  In pracitce that means you will need access to a broker running on a server or in the cloud somewhere and you will need to create topics on the broker to hold the streams.  If these concepts are new to you we suggest contacting us for assistance and/or using a simple, managed cloud solution, such as Confluent Cloud, as your broker. 
 
 ### Quick Start 
-####Overview of Installation:
+#### Overview of Installation:
 
 Here is an outline of the installation steps that are detailed below: 
 
@@ -39,19 +39,19 @@ Here is an outline of the installation steps that are detailed below:
 
 **NOTE:** Please read the entire installation section below before proceeding.  There are specific difference between instructions for Windows, Linux, Intel-MacOS, and M1-MacOS. 
 
-####1. miniconda3 Installation
+#### 1. miniconda3 Installation
 
 We recommend using miniconda3 for the lightest installation. miniconda3 installers can be downloaded from [the website here](https://docs.conda.io/en/latest/miniconda.html), and installation instructions can be found on [the website here](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
 
-####2. Conda Environment Creation
+#### 2. Conda Environment Creation
+
 With Miniconda installed, create and activate a dedicated virtual environment for OpenMSI. In a terminal shell (or Anaconda Prompt in admin mode on Windows) type:
 
 ```
 conda create -n openmsi python=3.9
 conda activate openmsi
 ```
-#####N.B. Different Conda Step for Older Versions of Windows:
-
+##### N.B. Different Conda Step for Older Versions of Windows:
 
 Python 3.9 is not supported on Windows 7 or earlier. Installations on pre-Windows 10 systems should, therefore, use Python 3.7 instead of Python 3.9, in which case, replace the two commands above with:
 
@@ -62,7 +62,7 @@ conda activate openmsi
 
 *In principle* `OpenMSIPython` code is transparent to the difference between Python 3.7 and 3.9, but it is recommended to use newer Windows systems that can support Python 3.9
 
-######Issues with DLL Files:
+###### Issues with DLL Files:
 
 On Windows, you need to set a special variable in the virtual environment to allow the Kafka Python code to find its dependencies (see [here](https://github.com/ContinuumIO/anaconda-issues/issues/12475) for more details). To do this, activate your Conda environment as above then type the following commands to set the variable and then refresh the environment:
 
@@ -72,24 +72,21 @@ conda deactivate
 conda activate openmsi
 ```
 
-Due to the wide variety of Windows builds, setting this environment variable may not solve all issues stemming from the `librdkafka.dll` file seemingly missing. See [here](https://github.com/confluentinc/confluent-kafka-python/issues/1221) for more context on this problem. A fix for the most common cases is built into `OpenMSIPython` and can be found [here](./openmsipython/my_kafka/__init__.py); referencing that code may be helpful in resolving any remaining `librdkafka`/`confluent-kafka-python` issues.
+###### More Details about Versions:
 
-Another common issue with Windows builds is a seemingly missing `libsodium.dll` file. If you encounter errors stating trouble importing `pysodium`, make sure the directory containing your `libsodium.dll` is added to your `PATH`, or that the `libsodium.dll` file is properly registered on your Windows system.
+At the time of writing, Python 3.9 is the most recent release of Python supported by confluent-kafka on Windows 10, and is recommended for most deployments. 
 
+##### General Virtual Environment Note:
 
-######More Details about Versions:
-At the time of writing this ReadMe, Python 3.9 is the most recent release of Python supported by confluent-kafka on Windows 10, and is recommended for most deployments. 
-
-
-#####General Virtual Environment Note:
 No matter the operating system, you'll need to use the second command to "activate" the openmsi environment every time you open a Terminal window or Anaconda Prompt and want to work with OpenMSIPython. 
 
-####3. Install libsodium
-`libsodium` is a package used for the KakfaCrypto package that provides the end-to-end data encryption capability of OpenMSIPython. Since encryption is a built-in option for OpenMSIPython, you must install `libsodium` even if you don't want to use encryption. Install the `libsodium` package through Miniconda using the shell command:
+#### 3. Install libsodium
+
+`libsodium` is a package used for the [KafkaCrypto](https://github.com/tmcqueen-materials/kafkacrypto) package that provides the end-to-end data encryption capability of `OpenMSIPython`. Since encryption is a built-in option for `OpenMSIPython`, you must install `libsodium` even if you don't want to use encryption. Install the `libsodium` package through Miniconda using the shell command:
 
 `conda install -c anaconda libsodium`
 
-####4. Install git if necessary
+#### 4. Install git if necessary
 
 If your system does not have git installed, you can do so with conda.  If you need to check to see if git is installed use:
 
@@ -99,7 +96,7 @@ If it is not present then install it with
 
 'conda install -c anaconda git`
 
-####5. Install librdkafka for Macs (this step not required on Windows)
+#### 5. Install librdkafka for Macs (this step not required on Windows)
 
 MacOS is not officially supported for `OpenMSIPython`, but works reliably at this time. If you would like to work with MacOS you will, however, need to install `librdkafka` using the package manager homebrew. The process is different on Intel-Chip Macs than on newer Apple-Silicon, M1 Mac.  
 
@@ -112,33 +109,26 @@ xcode-select --install
 brew install librdkafka
 ```
 
-Some Mac machines may also run into an esoteric issue related to the number of active file descriptors, which appears as repeated error messages like
-
-`% ERROR: Local: Host resolution failure: kafka-xyz.example.com:9092/42: Failed to resolve 'kafka-xyz.example.com:9092': nodename nor servname provided, or not known (after 0ms in state CONNECT)`
-
-when the Kafka server is otherwise available and should be fine, especially when using relatively large numbers of parallel threads. Instead of the above error, you may get `too many open files` errors.
-
-These errors may be due to running out of file descriptors as discussed in [this known `confluent-kafka`/`librdkafka` issue](https://github.com/edenhill/kcat/issues/209): using a broker hosted on Confluent Cloud may increase the likelihood of getting errors like these, because `librdkafka` creates two separate file descriptors for each known broker regardless of whether a connection is established. If you type `ulimit -n` into a Terminal window and get an output like `256`, it's likely this is the cause. To solve this issue, you will need to increase the limit of the number of allowed file descriptors, by running `ulimit -n 4096`. If that makes the errors go away, then you might want to add that line to your shell `.profile` or `.rc` file.
-
 ##### On M1 MacOS (tested on Monterey system):
-
 
 1. Change the default shell to Bash:
  
     `chsh -s /bin/bash`
 
-2. Install home-brew:
+2. Install Homebrew:
  
     `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
 3. Add homebrew bin and sbin locations to your path:
  
     `export PATH=/opt/homebrew/bin:$PATH`
     `export PATH=/opt/homebrew/sbin:$PATH`
+
 4. Use brew to install *librdkafka*:
  
     `brew install librdkafka`
 
-####6. Clone and Install OpenMSIPython from this Repo
+#### 6. Clone and Install OpenMSIPython from this Repo
 
 **Clone** this `openmsipython` github repo and change directory to openmsipython:
  
@@ -146,6 +136,7 @@ These errors may be due to running out of file descriptors as discussed in [this
     `cd openmsipython/`
 
 ##### N.B Extra Steps for M1 Macs:
+
 *On M1 Macs you need to define system paths to allow your system find the GCC compilers used while building things. You may need to edit these steps because they refer to the specific version number of librdkafka library (1.8.2 as of this writing). If the version of librdkafka your installed in step 7 is not 1.8.2, then edit these commands to refer to the actual version installed.*
  
     `CPATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include pip install confluent-kafka`
@@ -157,14 +148,16 @@ These errors may be due to running out of file descriptors as discussed in [this
     `brew install FreeTDS`  
     `pip3 install pymssql`
 
-
-**Install** openmsi:
+#### 7. **Install** openmsipython:
  
     `pip install .`
     `cd ..`
 
-####Installation Completion Note:
-**This completes installation on an M1 Mac and will give you access to several new console commands to run openmsipython applications, as well as any of the other modules in the `openmsipython` package. If you'd like to be able to make changes to the `openmsipython` code without reinstalling, you can include the `--editable` flag in the `pip install` command. If you'd like to run the automatic code tests, you can install the optional dependencies needed with `pip install .[all]` with or without the `--editable` flag.**
+If you'd like to be able to make changes to the `openmsipython` code without reinstalling, you can include the `--editable` flag in the `pip install` command. If you'd like to run the automatic code tests, you can install the optional dependencies needed with `pip install .[all]` with or without the `--editable` flag.
+
+#### Installation Completion Note:
+
+**This completes installation and will give you access to several new console commands to run `OpenMSIPython` applications, as well as any of the other modules in the `openmsipython` package.**
 
 If you like, you can check your installation with:
 
@@ -176,24 +169,33 @@ python
 
 and if that line runs without any problems then the package was installed correctly.
 
+#### 8. Environment variables (for Confluent Cloud or S3 Object Stores)
 
-####7. Environment variables (for Confluent Cloud or S3 Object Stores)
+Interacting with the Kafka broker on Confluent Cloud, including running code tests as described [here](./test), requires that some environment variables are set on your system. If you're installing any software to run as a Windows Service or Linux Daemon (as described [here](./openmsipython/services)) then you'll be prompted to enter these variables' values, but you may find it more convenient to set them once and save them as environment variables. 
 
-Interacting with the Kafka broker on Confluent Cloud, including running code tests as described [here](./test), requires that some environment variables are set on your system. If you're installing any software to run as a Windows Service or Linux Daemon (as described [here](./openmsipython/services)) then you'll be prompted to enter these variables' values, but you may find it more convenient to set them once and save them as environmental variable. The environment variables are called `KAFKA_TEST_CLUSTER_USERNAME`, `KAFKA_TEST_CLUSTER_PASSWORD`, `KAFKA_PROD_CLUSTER_USERNAME`, and `KAFKA_PROD_CLUSTER_PASSWORD`. The "`TEST`" variables are used to connect to the Kafka broker cluster for testing and must be set for developers needing to successfully run the automatic code tests. The "`PROD`" variables are used to connect to a full production cluster and are only needed for fully deployed code.
+The environment variables are called `KAFKA_TEST_CLUSTER_USERNAME`, `KAFKA_TEST_CLUSTER_PASSWORD`, `KAFKA_PROD_CLUSTER_USERNAME`, and `KAFKA_PROD_CLUSTER_PASSWORD`. The "`TEST`" variables are used to connect to the Kafka broker cluster for testing and must be set for developers needing to successfully run the automatic code tests. The "`PROD`" variables are used to connect to a full production cluster and are only needed for fully deployed code.
 
-You can set these environment variables in a shell `.rc` or `.profile` file if running on Linux or Mac OS. On Windows you can set them as machine environment variables using commands like `[Environment]::SetEnvironmentVariable("NAME","VALUE",[EnvironmentVariableTarget]::Machine)`. You can also set them as "User" or "Process" environment variables on Windows if you don't have the necessary permissions to set them for the "Machine". 
+You can set these environment variables in a shell `.rc` or `.profile` file if running on Linux or Mac OS. On Windows you can set them as machine environment variables using commands like:
 
-Secret keys for connecting to S3 object stores should similarly be stored as environment variables and referenced in config files, rather than hard-coded.
+```
+[Environment]::SetEnvironmentVariable("NAME","VALUE",[EnvironmentVariableTarget]::Machine)
+```
 
-####8. Provision KafkaCrypto Node (optional)
+You can also set them as "User" or "Process" environment variables on Windows if you don't have the necessary permissions to set them for the "Machine". 
+
+Secret keys for connecting to S3 object stores should similarly be stored as environment variables and referenced in config files, rather than hard-coded. For running tests, the S3 object store environment variable names are `ACCESS_SECRET_KEY_ID`, `BUCKET_NAME`, `ENDPOINT_URL`, `REGION`, and `SECRET_KEY_ID`.
+
+#### 9. Provision KafkaCrypto Node (optional)
+
 The [readme file here](./openmsipython/my_kafka) explains how to enable message-layer encryption through [KafkaCrypto](https://github.com/tmcqueen-materials/kafkacrypto).
 
-####9. Write Config File
+#### 10. Write Config File
+
 The [readme file here](./openmsipython/my_kafka) also explains options for configuration files used to define which kafka cluster(s) the programs interact with and how data are produced to/consumed from topics within them.
 
-####10. Install and Start Service or Daemon (optional)
-The [readme file here](./openmsipython/services) explains options and installation of OpenMSIPython programs continually as Windows Services or Linux Daemons.  
+#### 11. Install and Start Service or Daemon (optional)
 
+The [readme file here](./openmsipython/services) explains options and installation of OpenMSIPython programs continually as Windows Services or Linux Daemons.  
 
 ## Other documentation
 
@@ -220,6 +222,47 @@ The [readme file here](./openmsipython/data_models) describes how GEMD data stru
 The [readme file here](./openmsipython/pdv) explains programs used to upload specific portions of data in Lecroy Oscilloscope files and produce sheets of plots for PDV spall or velocity analyses.
 
 The [readme file here](./test) describes the automatic testing and CI/CD setup for the project, including how to run tests interactively and add additional tests.
+
+## Troubleshooting
+
+#### Missing .dll files on Windows
+
+Due to the wide variety of Windows builds, setting the conda environment variable above may not solve all issues stemming from the `librdkafka.dll` file seemingly missing. See [here](https://github.com/confluentinc/confluent-kafka-python/issues/1221) for more context on this problem. A fix for the most common cases is built into `OpenMSIPython` and can be found [here](./openmsipython/__init__.py); referencing that code may be helpful in resolving any remaining `librdkafka`/`confluent-kafka-python` issues.
+
+Another common issue with Windows builds is a seemingly missing `libsodium.dll` file. If you encounter errors stating trouble importing `pysodium`, make sure the directory containing your `libsodium.dll` is added to your `PATH`, or that the `libsodium.dll` file is properly registered on your Windows system.
+
+##### Missing .dll files running programs as Windows Services
+
+Issues with loading `.dll` files manifest differently when running `OpenMSIPython` code as Windows Services because Services run in `%WinDir%\System32` and don't read the same `PATH` locations as running interactively. Some workarounds are built into `OpenMSIPython` to mitigate these problems, but if you run into trouble with missing `.dll` files while running `OpenMSIPython` programs as Services they can typically be resolved by copying those files into the `%WinDir%\System32` directory.
+
+#### Mac OS "active file descriptors" error
+
+Some Mac machines may run into an esoteric issue related to the number of active file descriptors, which appears as repeated error messages like
+
+`% ERROR: Local: Host resolution failure: kafka-xyz.example.com:9092/42: Failed to resolve 'kafka-xyz.example.com:9092': nodename nor servname provided, or not known (after 0ms in state CONNECT)`
+
+when the Kafka server is otherwise available and should be fine, especially when using relatively large numbers of parallel threads. Instead of the above error, you may get `too many open files` errors.
+
+These errors may be due to running out of file descriptors as discussed in [this known `confluent-kafka`/`librdkafka` issue](https://github.com/edenhill/kcat/issues/209): using a broker hosted on Confluent Cloud may increase the likelihood of getting errors like these, because `librdkafka` creates two separate file descriptors for each known broker regardless of whether a connection is established. If you type `ulimit -n` into a Terminal window and get an output like `256`, it's likely this is the cause. To solve this issue, you will need to increase the limit of the number of allowed file descriptors, by running `ulimit -n 4096`. If that makes the errors go away, then you might want to add that line to your shell `.profile` or `.rc` file.
+
+#### Older operating systems and SSL errors
+
+Some machines may experience errors in connecting to Kafka brokers because their operating systems are old enough to have a set of ca certificates that won't work with new certificates on many sites. If you see repeated errors like
+
+`FAIL|rdkafka#consumer-2| [thrd:ssl://kafka-xyz.example.com:9092/42]: ssl://kafka-xyz.example.com:9092/42: SSL handshake failed: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed: broker certificate could not be verified, verify that ssl.ca.location is correctly configured or root CA certificates are installed (install ca-certificates package)`
+
+you should be able to solve this issue by installing "certifi" with pip:
+
+```
+pip install --upgrade certifi
+```
+
+and then adding the location of the CA file it installed to the `[broker]` section of your config file as `ssl.ca.location`. You can find the location of the CA file by running a couple lines in Python:
+
+```
+>>> import certifi
+>>> certifi.where()
+```
 
 ## To-do list
 


### PR DESCRIPTION
Major rewrite to make one continuous flow with detail variances for Windows, Intel-MacOS, and M1-MacOS all in place.  Details for Crypto, Config files, and services/daemons just reference ReadMe's in appropriate directories.  Needs Maggie's review for readability and then merge into Main if no issues.