### PR TITLE
Use multiple Producers in UploadDataFile and DataFileUploadDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <div align="center"> Open MSI Python Code </div>
-#### <div align="center">***v0.9.3.5***</div>
+#### <div align="center">***v0.9.3.6***</div>
 
 #### <div align="center">Maggie Eminizer<sup>2</sup>, Amir Sharifzadeh<sup>2</sup>, Sam Tabrisky<sup>3</sup>, Alakarthika Ulaganathan<sup>4</sup>, David Elbert<sup>1</sup></div>
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ site.ENABLE_USER_SITE = True #https://www.scivision.dev/python-pip-devel-user-in
 
 setupkwargs = dict(
     name='openmsipython',
-    version='0.9.3.5',
+    version='0.9.3.6',
     packages=setuptools.find_packages(include=['openmsipython*']),
     include_package_data=True,
     entry_points = {


### PR DESCRIPTION
There used to be multiple instances of a single producer listening to a Queue of chunks to produce. Each one of those instances now has its own Producer.